### PR TITLE
Verkerk reorder points

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of threedidepth
 0.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Reorder to match the lizard triangulation.
 
 
 0.2 (2020-12-10)

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -12,6 +12,7 @@ from threedigrid.admin.gridresultadmin import GridH5ResultAdmin
 from threedigrid.admin.constants import SUBSET_2D_OPEN_WATER
 from threedigrid.admin.constants import NO_DATA_VALUE
 from threedidepth.fixes import fix_gridadmin
+from threedidepth import morton
 
 MODE_COPY = "copy"
 MODE_NODGRID = "nodgrid"
@@ -137,8 +138,12 @@ class Calculator:
             timeseries = nodes.timeseries(indexes=[self.calculation_step])
             data = timeseries.only("s1", "coordinates").data
             points = data["coordinates"].transpose()
-            delaunay = qhull.Delaunay(points)
             s1 = data["s1"][0]
+
+            # reorder a la lizard
+            points, s1 = morton.reorder(points, s1)
+
+            delaunay = qhull.Delaunay(points)
             self.cache[self.DELAUNAY] = delaunay, s1
             return delaunay, s1
 

--- a/test/test_calculate.py
+++ b/test/test_calculate.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from unittest import mock
 import random
 import string
-import sys
 
 from numpy.testing import assert_allclose
 from osgeo import gdal
@@ -27,7 +26,6 @@ from threedidepth.calculate import MODE_CONSTANT
 from threedidepth.calculate import MODE_LINEAR
 from threedidepth.calculate import MODE_LIZARD
 from threedidepth.calculate import SUBSET_2D_OPEN_WATER
-from threedidepth.commands import threedidepth
 
 RD = osr.GetUserInputAsWKT("EPSG:28992")
 NDV = -9  # no data value of the test dem

--- a/test/test_morton.py
+++ b/test/test_morton.py
@@ -24,6 +24,13 @@ def test_morton_array():
         morton.morton_array((2 ** 32, 2 ** 32))
 
 
+def test_group():
+    array = np.array([0.6, 0.6, 0.6, 0.5, 0.7, 0.5, 0.7, 0.5, 0.7])
+    expected = [[3, 5, 7], [0, 1, 2], [4, 6, 8]]
+    result = [i.tolist() for i in morton.group(array)]
+    assert result == expected
+
+
 def test_rasterize():
     # single point
     points = np.array([[0, 0]])
@@ -43,11 +50,24 @@ def test_rasterize():
     result = morton.rasterize(points)[0].tolist()
     assert result == expected
 
-    # quadtree - here is a problem
+    # quadtree
     points = np.array([[1, 1], [3, 1], [1, 3], [3, 3], [6, 2]])
     expected = [
-        [2, 3, 4, 5],
-        [0, 1, 5, 5],
+        [2, 3, 4],
+        [0, 1, 5],
     ]
     result = morton.rasterize(points)[0].tolist()
-    # assert result == expected
+    assert result == expected
+
+
+def test_reorder():
+    points = np.array([[1, 3], [3, 1], [6, 2], [3, 3], [1, 1]])
+    s1 = np.array([1, 2, 3, 4, 5])
+
+    result_points, result_s1 = morton.reorder(points, s1)
+
+    expected_points = [[1, 3], [3, 3], [1, 1], [3, 1], [6, 2]]
+    expected_s1 = [1, 4, 5, 2, 3]
+
+    assert result_points.tolist() == expected_points
+    assert result_s1.tolist() == expected_s1

--- a/test/test_morton.py
+++ b/test/test_morton.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+import numpy as np
+
 from threedidepth import morton
 
 
@@ -20,3 +22,32 @@ def test_morton_array():
     assert morton.morton_array((1, 2)).tolist() == [[0, 1]]
     with pytest.raises(ValueError):
         morton.morton_array((2 ** 32, 2 ** 32))
+
+
+def test_rasterize():
+    # single point
+    points = np.array([[0, 0]])
+    expected = [[0]]
+    result = morton.rasterize(points)[0].tolist()
+    assert result == expected
+
+    # horizontal
+    points = np.array([[0, 0], [1, 0]])
+    expected = [[0, 1]]
+    result = morton.rasterize(points)[0].tolist()
+    assert result == expected
+
+    # vertical
+    points = np.array([[0, 0], [1, 0]])
+    expected = [[0, 1]]
+    result = morton.rasterize(points)[0].tolist()
+    assert result == expected
+
+    # quadtree - here is a problem
+    points = np.array([[1, 1], [3, 1], [1, 3], [3, 3], [6, 2]])
+    expected = [
+        [2, 3, 4, 5],
+        [0, 1, 5, 5],
+    ]
+    result = morton.rasterize(points)[0].tolist()
+    # assert result == expected


### PR DESCRIPTION
I commited the morton stuff that I copied from raster-store result_processing straight to master, to facilitate reviewing.

I chose a route that does neither involve too much copying raster-store result processing logic, nor employing the high resolution nodgrid from threedigrid, but instead created a sort-of-nodgrid straight from the node coordinates.