### PR TITLE
netcdf exporter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ importlib-metadata==1.7.0
 importlib-resources==3.0.0
 keyring==10.6.0
 keyrings.alt==3.0
+netCDF4==1.5.6
 numpy==1.19.5
 pycrypto==2.6.1
 pygobject==3.26.1

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -320,13 +320,20 @@ class GeoTIFFConverter:
         source_path (str): Path to source GeoTIFF file.
         target_path (str): Path to target GeoTIFF file.
         progress_func: a callable.
-        calculation_steps (list(int)): indexes of calculation steps for the waterdepth
+        calculation_steps (list(int)): indexes of calculation steps for the
+            waterdepth
 
         The progress_func will be called multiple times with values between 0.0
         amd 1.0.
     """
 
-    def __init__(self, source_path, target_path, progress_func=None, calculation_steps=None):
+    def __init__(
+            self,
+            source_path,
+            target_path,
+            progress_func=None,
+            calculation_steps=None
+    ):
         self.source_path = source_path
         self.target_path = target_path
         self.progress_func = progress_func
@@ -461,15 +468,11 @@ class NetcdfConverter(GeoTIFFConverter):
     def __enter__(self):
         """Open datasets"""
         self.source = gdal.Open(self.source_path, gdal.GA_ReadOnly)
-        block_x_size, block_y_size = self.block_size
-        options = ["compress=deflate", "blocksize=%s" % block_y_size, "format=NC4"]
-        if block_x_size != self.raster_x_size:
-            options += ["tiled=yes", "blockxsize=%s" % block_x_size]
-
-        self.gridadmin = GridH5ResultAdmin(self.gridadmin_path, self.results_3di_path)
+        self.gridadmin = GridH5ResultAdmin(
+            self.gridadmin_path, self.results_3di_path
+        )
 
         self.target = netCDF4.Dataset(self.target_path, "w", format="NETCDF4")
-
         self._set_lat_lon()
         self._set_time()
         self._set_meta_info()
@@ -530,7 +533,11 @@ class NetcdfConverter(GeoTIFFConverter):
     def convert_using(self, calculator):
         """Convert data writing it to netcdf4."""
         water_depth = self.target.createVariable(
-            "water_depth", "f4", ("time", "lat", "lon",), fill_value=-9999, zlib=True
+            "water_depth",
+            "f4",
+            ("time", "lat", "lon",),
+            fill_value=-9999,
+            zlib=True
         )
         water_depth.long_name = "water depth"
         water_depth.units = "m"

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -545,6 +545,14 @@ class NetcdfConverter(GeoTIFFConverter):
         longitude.units = "degree_east"
         longitude.axis = "X"
 
+        projection = self.target.createVariable(
+            "projected_coordinate_system", "i4"
+        )
+        projection.EPSG_code = f"EPSG:{self.gridadmin.epsg_code}"
+        projection.epsg = self.gridadmin.epsg_code
+        projection.long_name = "Spatial Reference"
+
+
     def convert_using(self, calculator):
         """Convert data writing it to netcdf4."""
         water_depth = self.target.createVariable(

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -552,7 +552,6 @@ class NetcdfConverter(GeoTIFFConverter):
         projection.epsg = self.gridadmin.epsg_code
         projection.long_name = "Spatial Reference"
 
-
     def convert_using(self, calculator):
         """Convert data writing it to netcdf4."""
         water_depth = self.target.createVariable(

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -71,6 +71,15 @@ class Calculator:
         """
         raise NotImplementedError
 
+    @property
+    def calculation_step(self):
+        return self._calculation_step
+
+    @calculation_step.setter
+    def calculation_step(self, value):
+        self.cache = {}
+        self._calculation_step = value
+
     @staticmethod
     def _depth_from_water_level(dem, fillvalue, waterlevel):
         # determine depth

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -515,9 +515,13 @@ class NetcdfConverter(GeoTIFFConverter):
 
         self.target.createDimension("lat", self.raster_y_size)
         latitudes = self.target.createVariable("lat", "f4", ("lat",))
+
+        # In CF-1.6 the coordinates are cell centers, while GDAL interprets
+        # them as the upper-left corner.
+        y_upper_left = geotransform[3] + geotransform[5] / 2
         latitudes[:] = np.arange(
-            geotransform[3],
-            geotransform[3] + geotransform[5] * self.raster_y_size,
+            y_upper_left,
+            y_upper_left + geotransform[5] * self.raster_y_size,
             geotransform[5]
         )
         latitudes.standard_name = "latitude"
@@ -527,9 +531,13 @@ class NetcdfConverter(GeoTIFFConverter):
 
         self.target.createDimension("lon", self.raster_x_size)
         longitude = self.target.createVariable("lon", "f4", ("lon",))
+
+        # CF 1.6 coordinates are cell center, while GDAL interprets
+        # them as the upper-left corner.
+        x_upper_left = geotransform[0] + geotransform[1] / 2
         longitude[:] = np.arange(
-            geotransform[0],
-            geotransform[0] + geotransform[1] * self.raster_x_size,
+            x_upper_left,
+            x_upper_left + geotransform[1] * self.raster_x_size,
             geotransform[1]
         )
         longitude.standard_name = "longitude"

--- a/src/threedidepth/commands.py
+++ b/src/threedidepth/commands.py
@@ -51,6 +51,12 @@ def threedidepth(*args):
         const=gdal.TermProgress_nocb,
         help="Show progress.",
     )
+    parser.add_argument(
+        "-n",
+        "--netcdf",
+        action="store_true",
+        help="export the waterdepth as a netcdf"
+    )
     kwargs = vars(parser.parse_args())
     if kwargs.pop("constant"):
         kwargs["mode"] = MODE_CONSTANT

--- a/src/threedidepth/commands.py
+++ b/src/threedidepth/commands.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import sys
 
 from osgeo import gdal
 
@@ -29,11 +30,12 @@ def threedidepth(*args):
     )
     parser.add_argument(
         "-s",
-        "--step",
+        "--steps",
+        nargs="+",
         type=int,
-        default=-1,
-        dest="calculation_step",
-        help="simulation result step",
+        default=[-1, ],
+        dest="calculation_steps",
+        help="simulation result step(s)",
     )
     parser.add_argument(
         "-c",
@@ -55,3 +57,7 @@ def threedidepth(*args):
     else:
         kwargs["mode"] = MODE_LIZARD
     calculate_waterdepth(**kwargs)
+
+
+if __name__ == '__main__':
+    threedidepth(sys.argv)

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -18,7 +18,7 @@ def test_command(tmpdir):
             results_3di_path="b",
             dem_path="c",
             waterdepth_path="d",
-            calculation_step=-1,
+            calculation_steps=[-1],
             mode=commands.MODE_LIZARD,
             progress_func=None,
         )
@@ -30,7 +30,26 @@ def test_command(tmpdir):
             results_3di_path="b",
             dem_path="c",
             waterdepth_path="d",
-            calculation_step=-1,
+            calculation_steps=[-1],
             mode=commands.MODE_CONSTANT,
             progress_func=None,
+        )
+
+
+def test_command_with_multiple_steps(tmpdir):
+    depth_path = tmpdir.join("waterdepth.tif")
+    depth_path.ensure(file=True)  # "touch" the file
+    with mock.patch("threedidepth.commands.calculate_waterdepth") as wd:
+        args = ["threedidepth,", "a", "b", "c", "d", "--steps", "1", "2", "3"]
+        with mock.patch.object(sys, "argv", args):
+            commands.threedidepth()
+        wd.assert_called_with(
+            gridadmin_path="a",
+            results_3di_path="b",
+            dem_path="c",
+            waterdepth_path="d",
+            calculation_steps=[1, 2, 3],
+            mode=commands.MODE_LIZARD,
+            progress_func=None,
+            netcdf=False
         )

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -21,6 +21,7 @@ def test_command(tmpdir):
             calculation_steps=[-1],
             mode=commands.MODE_LIZARD,
             progress_func=None,
+            netcdf=False
         )
         args.append("--constant")
         with mock.patch.object(sys, "argv", args):
@@ -33,6 +34,7 @@ def test_command(tmpdir):
             calculation_steps=[-1],
             mode=commands.MODE_CONSTANT,
             progress_func=None,
+            netcdf=False
         )
 
 


### PR DESCRIPTION
Adds an extra converter: `NetcdfConverter`.
This converter saves the waterdepth rasters in a netcdf4 file according to the CF1.6 standards. It also allows to save the waterdepth rasters of multiple `calculation_steps` in one netcdf-file, by stacking the rasters in the time dimension.

The stacking of rasters has also been added to the `GeoTIFFConverter` for consistency. In this case each waterdepth raster will be stored on a seperate band.


The command line has an extra flag `-n / --netcdf` to save the file as a netcdf instead of a geotiff (defaults to geotiff). 
Also the `-s CALCUALTION_STEPS` now accepts multiple steps (defaults to -1, the last calculation_step).

![image](https://user-images.githubusercontent.com/11858775/109829729-1958d200-7c3e-11eb-803f-3c8d20fbef6c.png)

TODO:
- [x] fix progress in `partition()`
- [x] Add tests for NetcdfConverter
