### PR TITLE
19 add maximum waterdepth output that aggregates all calculation steps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of threedidepth
 0.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Update dependency versions
+- Add support for calculating maximum waterlevel as well as per timestep.
 
 
 0.5 (2021-07-02)

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,11 @@ Calculate waterdepths for 3Di results. For results of type 'raw' the variable
 For the interpolated mode, the 'lizard'-method is used. For a detailed
 description, read the docstring for the `LizardLevelCalculator`.
 
+For the maximum waterlevel calculation, the maximum waterlevel for each point
+is taken before the interpolation is applied. This can lead to situations where
+the highest waterlevel for a pixel for a certain timestep is higher than the
+maximum waterlevel for the pixel.
+
 
 Installation
 ------------

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -44,10 +44,13 @@ class BaseCalculator:
     DELAUNAY = "delaunay"
 
     def __init__(
-        self, result_admin, dem_shape, dem_geo_transform, calculation_step=None, get_max_level=False
+        self, result_admin, dem_shape, dem_geo_transform,
+        calculation_step=None, get_max_level=False
     ):
         if calculation_step is None and not get_max_level:
-            raise ValueError("a calculation_step is required unless get_max_level is True")
+            raise ValueError(
+                "a calculation_step is required unless get_max_level is True"
+            )
         self.ra = result_admin
         self.calculation_step = calculation_step
         self.get_max_level = get_max_level
@@ -105,11 +108,16 @@ class BaseCalculator:
         except KeyError:
             nodes = self.ra.nodes.subset(SUBSET_2D_OPEN_WATER)
             if self.get_max_level:
-                timeseries = nodes.timeseries(indexes=slice(0, self.ra.calculation_steps))  # array van Ntimesteps * Nnodes
+                # array van Ntimesteps * Nnodes
+                timeseries = nodes.timeseries(
+                    indexes=slice(0, self.ra.calculation_steps)
+                )
                 data = timeseries.only(self.ra.variable, "id").data
                 s1 = np.max(data[self.ra.variable], axis=0)
             else:
-                timeseries = nodes.timeseries(indexes=self.indexes(self.calculation_step))
+                timeseries = nodes.timeseries(
+                    indexes=self.indexes(self.calculation_step)
+                )
                 data = timeseries.only(self.ra.variable, "id").data
                 s1 = data[self.ra.variable][0]
             lookup_s1 = np.full((data["id"]).max() + 1, NO_DATA_VALUE)
@@ -455,7 +463,7 @@ class NetcdfConverter(GeoTIFFConverter):
             target_path,
             result_admin,
             calculation_steps,
-            write_time_dimension = True,
+            write_time_dimension=True,
             **kwargs
     ):
         kwargs["band_count"] = len(calculation_steps)
@@ -470,7 +478,6 @@ class NetcdfConverter(GeoTIFFConverter):
         self.source = gdal.Open(self.source_path, gdal.GA_ReadOnly)
         self.target = netCDF4.Dataset(self.target_path, "w")
         self._set_coords()
-        # TODO: make conditional on not get_max_level BEFORE merging into master
         if self.write_time_dimension:
             self._set_time()
         self._set_meta_info()
@@ -552,7 +559,7 @@ class NetcdfConverter(GeoTIFFConverter):
         water_depth = self.target.createVariable(
             "water_depth",
             "f4",
-            (("time", "y", "x",) if self.write_time_dimension else ("y", "x",)),
+            ("time", "y", "x",) if self.write_time_dimension else ("y", "x",),
             fill_value=-9999,
             zlib=True
         )
@@ -581,7 +588,9 @@ class NetcdfConverter(GeoTIFFConverter):
             # write
             water_depth = self.target['water_depth']
             if self.write_time_dimension:
-                water_depth[band, yoff:yoff + ysize, xoff:xoff + xsize] = result
+                water_depth[
+                    band, yoff:yoff + ysize, xoff:xoff + xsize
+                ] = result
             else:
                 water_depth[yoff:yoff + ysize, xoff:xoff + xsize] = result
 
@@ -728,7 +737,9 @@ def calculate_waterdepth(
         converter_class = NetcdfConverter
         converter_kwargs['result_admin'] = result_admin
         converter_kwargs['calculation_steps'] = calculation_steps
-        converter_kwargs['write_time_dimension'] = not calculate_maximum_waterlevel
+        converter_kwargs[
+            'write_time_dimension'
+        ] = not calculate_maximum_waterlevel
     else:
         converter_class = GeoTIFFConverter
         converter_kwargs['band_count'] = len(calculation_steps)

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -6,7 +6,7 @@ from os import path
 from osgeo import gdal
 from osgeo import osr
 from scipy.interpolate import LinearNDInterpolator
-from scipy.spatial import qhull
+from scipy.spatial import Delaunay
 import h5netcdf.legacyapi as netCDF4
 import h5py
 import numpy as np
@@ -129,7 +129,7 @@ class BaseCalculator:
         """
         Return a (delaunay, s1) tuple.
 
-        `delaunay` is a qhull.Delaunay object, and `s1` is an array of
+        `delaunay` is a scipy.spatial.Delaunay object, and `s1` is an array of
         waterlevels for the corresponding delaunay simplices.
         """
         try:
@@ -144,7 +144,7 @@ class BaseCalculator:
             # reorder a la lizard
             points, s1 = morton.reorder(points, s1)
 
-            delaunay = qhull.Delaunay(points)
+            delaunay = Delaunay(points)
             self.cache[self.DELAUNAY] = delaunay, s1
             return delaunay, s1
 

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -657,6 +657,7 @@ def calculate_waterdepth(
     dem_path,
     waterdepth_path,
     calculation_steps=None,
+    calculate_maximum_waterlevel=False,
     mode=MODE_LIZARD,
     progress_func=None,
     netcdf=False,

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -130,7 +130,7 @@ class BaseCalculator:
         Return a (delaunay, s1) tuple.
 
         `delaunay` is a qhull.Delaunay object, and `s1` is an array of
-        waterlevels for the corresponding delaunay vertices.
+        waterlevels for the corresponding delaunay simplices.
         """
         try:
             return self.cache[self.DELAUNAY]
@@ -243,18 +243,18 @@ class LizardLevelCalculator(BaseCalculator):
 
         # get the nodes and the transform for the corresponding triangles
         transform = delaunay.transform[simplices[in_interpol]]
-        vertices = delaunay.vertices[simplices[in_interpol]]
+        simplices = delaunay.simplices[simplices[in_interpol]]
 
         # calculate weight, see print(spatial.Delaunay.transform.__doc__) and
         # Wikipedia about barycentric coordinates
-        weight = np.empty(vertices.shape)
+        weight = np.empty(simplices.shape)
         weight[:, :2] = np.sum(
             transform[:, :2] * (points - transform[:, 2])[:, np.newaxis], 2
         )
         weight[:, 2] = 1 - weight[:, 0] - weight[:, 1]
 
         # set weight to zero when for inactive nodes
-        nodelevel = s1[vertices]
+        nodelevel = s1[simplices]
         weight[nodelevel == NO_DATA_VALUE] = 0
 
         # determine the sum of weights per result cell

--- a/src/threedidepth/calculate.py
+++ b/src/threedidepth/calculate.py
@@ -105,7 +105,7 @@ class BaseCalculator:
         except KeyError:
             nodes = self.ra.nodes.subset(SUBSET_2D_OPEN_WATER)
             if self.get_max_level:
-                timeseries = nodes.timeseries(start_time=0, end_time=self.ra.get_timestamps(self.ra.calculation_steps-1))  # array van Ntimesteps * Nnodes
+                timeseries = nodes.timeseries(indexes=slice(0, self.ra.calculation_steps))  # array van Ntimesteps * Nnodes
                 data = timeseries.only(self.ra.variable, "id").data
                 s1 = np.max(data[self.ra.variable], axis=0)
             else:

--- a/src/threedidepth/commands.py
+++ b/src/threedidepth/commands.py
@@ -41,7 +41,7 @@ def threedidepth(*args):
         "--maximum",
         action="store_true",
         dest="calculate_maximum_waterlevel",
-        help="calculate maximum waterlevel instead of waterlevel at specific timestep(s)",
+        help="calculate maximum waterlevel instead of waterlevel per timestep",
     )
     parser.add_argument(
         "-c",

--- a/src/threedidepth/commands.py
+++ b/src/threedidepth/commands.py
@@ -28,13 +28,20 @@ def threedidepth(*args):
         metavar="waterdepth",
         help="path to resulting geotiff"
     )
-    parser.add_argument(
+    calculation_type_group = parser.add_mutually_exclusive_group()
+    calculation_type_group.add_argument(
         "-s",
         "--steps",
         nargs="+",
         type=int,
         dest="calculation_steps",
         help="simulation result step(s)",
+    )
+    calculation_type_group.add_argument(
+        "--maximum",
+        action="store_true",
+        dest="calculate_maximum_waterlevel",
+        help="calculate maximum waterlevel instead of waterlevel at specific timestep(s)",
     )
     parser.add_argument(
         "-c",

--- a/test/test_calculate.py
+++ b/test/test_calculate.py
@@ -327,14 +327,13 @@ def test_calculators(mode, expected, admin):
     admin.variable = "s1"
     if mode in (MODE_CONSTANT_S1):
         data = {"id": ids, "s1": s1}
-        admin.nodes.subset().timeseries().only().data = data
+        admin.nodes.subset().timeseries().only().data = admin.nodes.subset().only().data = data
     if mode in (MODE_LINEAR_S1):
-        data = {"coordinates": coordinates, "s1": s1}
-        admin.nodes.subset().timeseries().only().data = data
+        data = {"id": ids, "coordinates": coordinates, "s1": s1}
+        admin.nodes.subset().timeseries().only().data = admin.nodes.subset().only().data = data
     if mode in (MODE_LIZARD_S1):
-        admin.nodes.subset().timeseries().only.side_effect = [
-            mock.Mock(data={"id": ids, "s1": s1}),
-            mock.Mock(data={"coordinates": coordinates, "s1": s1}),
+        admin.nodes.subset().timeseries().only.side_effect = admin.nodes.subset().only.side_effect = [
+            mock.Mock(data={"id": ids, "coordinates": coordinates, "s1": s1})
         ]
 
     indexes = slice(7, 8)
@@ -367,7 +366,7 @@ def test_calculators(mode, expected, admin):
         admin.nodes.subset.assert_called_with(SUBSET_2D_OPEN_WATER)
         admin.nodes.subset().timeseries.assert_called_with(indexes=indexes)
         admin.nodes.subset().timeseries().only.assert_called_with(
-            "s1", "coordinates",
+            "s1", "id",
         )
     if mode in (MODE_CONSTANT_S1):
         admin.nodes.subset.assert_called_with(SUBSET_2D_OPEN_WATER)
@@ -379,7 +378,7 @@ def test_calculators(mode, expected, admin):
         admin.nodes.subset.assert_called_with(SUBSET_2D_OPEN_WATER)
         admin.nodes.subset().timeseries.assert_called_with(indexes=indexes)
         admin.nodes.subset().timeseries().only.assert_has_calls(
-            [mock.call("s1", "id"), mock.call("s1", "coordinates")]
+            [mock.call("s1", "id")]
         )
 
 

--- a/test/test_calculate.py
+++ b/test/test_calculate.py
@@ -327,12 +327,17 @@ def test_calculators(mode, expected, admin):
     admin.variable = "s1"
     if mode in (MODE_CONSTANT_S1):
         data = {"id": ids, "s1": s1}
-        admin.nodes.subset().timeseries().only().data = admin.nodes.subset().only().data = data
+        admin.nodes.subset().timeseries().only().data = data
+        admin.nodes.subset().only().data = data
     if mode in (MODE_LINEAR_S1):
         data = {"id": ids, "coordinates": coordinates, "s1": s1}
-        admin.nodes.subset().timeseries().only().data = admin.nodes.subset().only().data = data
+        admin.nodes.subset().timeseries().only().data = data
+        admin.nodes.subset().only().data = data
     if mode in (MODE_LIZARD_S1):
-        admin.nodes.subset().timeseries().only.side_effect = admin.nodes.subset().only.side_effect = [
+        admin.nodes.subset().timeseries().only.side_effect = [
+            mock.Mock(data={"id": ids, "coordinates": coordinates, "s1": s1})
+        ]
+        admin.nodes.subset().only.side_effect = [
             mock.Mock(data={"id": ids, "coordinates": coordinates, "s1": s1})
         ]
 

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -72,5 +72,3 @@ def test_command_with_multiple_steps(tmpdir):
             progress_func=None,
             netcdf=False
         )
-
-

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -38,6 +38,20 @@ def test_command(tmpdir):
             progress_func=None,
             netcdf=False
         )
+        args.append("--maximum")
+        with mock.patch.object(sys, "argv", args):
+            commands.threedidepth()
+        wd.assert_called_with(
+            gridadmin_path="a",
+            results_3di_path="b",
+            dem_path="c",
+            waterdepth_path="d",
+            calculation_steps=None,
+            mode=commands.MODE_CONSTANT,
+            calculate_maximum_waterlevel=True,
+            progress_func=None,
+            netcdf=False
+        )
 
 
 def test_command_with_multiple_steps(tmpdir):
@@ -58,3 +72,5 @@ def test_command_with_multiple_steps(tmpdir):
             progress_func=None,
             netcdf=False
         )
+
+

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -20,6 +20,7 @@ def test_command(tmpdir):
             waterdepth_path="d",
             calculation_steps=None,
             mode=commands.MODE_LIZARD,
+            calculate_maximum_waterlevel=False,
             progress_func=None,
             netcdf=False
         )
@@ -33,6 +34,7 @@ def test_command(tmpdir):
             waterdepth_path="d",
             calculation_steps=None,
             mode=commands.MODE_CONSTANT,
+            calculate_maximum_waterlevel=False,
             progress_func=None,
             netcdf=False
         )
@@ -52,6 +54,7 @@ def test_command_with_multiple_steps(tmpdir):
             waterdepth_path="d",
             calculation_steps=[1, 2, 3],
             mode=commands.MODE_LIZARD,
+            calculate_maximum_waterlevel=False,
             progress_func=None,
             netcdf=False
         )


### PR DESCRIPTION
This PR adds an option to return the maximum water depth per pixel over all timesteps, instead of the water depth per pixel for every timestep.